### PR TITLE
Add repeat action

### DIFF
--- a/src/main/java/network/palace/show/Show.java
+++ b/src/main/java/network/palace/show/Show.java
@@ -222,7 +222,7 @@ public class Show {
         actions.clear();
     }
 
-    private ShowAction parseAction(String strLine, String[] args, long time, int start) throws ShowParseException {
+    public ShowAction parseAction(String strLine, String[] args, long time, int start) throws ShowParseException {
         ShowAction action;
         if (args[start].contains("Text")) {
             // Text
@@ -494,14 +494,16 @@ public class Show {
             nearPlayers[i++] = Core.getPlayerManager().getPlayer(uuid);
         }
 
-        long timeDiff = System.currentTimeMillis() - startTime;
+        long timeDiff = getShowTime();
 
         for (ShowAction action : new LinkedList<>(laterActions)) {
             if (action == null) continue;
             try {
                 if (timeDiff < action.getTime()) continue;
                 try {
-                    action.play(nearPlayers);
+                    if (!action.play(nearPlayers)) continue;
+                    // If false, it needs to continue being run
+                    // If true, it will continue down to be removed from the list of actions
                 } catch (Exception e) {
                     Core.logMessage("Show " + action.getShow().getName(), "Error playing action in show " + action.getShow().getName());
                 }
@@ -531,6 +533,10 @@ public class Show {
         firstAction = temp;
         if (sequences != null) ShowUtil.runSequences(sequences, startTime);
         return firstAction == null && this.sequences.isEmpty() && laterActions.isEmpty();
+    }
+
+    public long getShowTime() {
+        return System.currentTimeMillis() - startTime;
     }
 
     public void displayText(String text) {

--- a/src/main/java/network/palace/show/Show.java
+++ b/src/main/java/network/palace/show/Show.java
@@ -193,209 +193,8 @@ public class Show {
                 for (String timeStr : timeToks) {
                     time += (long) (Double.parseDouble(timeStr) * 1000);
                 }
-                // Text
-                if (args[1].contains("Text")) {
-                    TextAction ac = new TextAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Music
-                if (args[1].contains("Music")) {
-                    MusicAction ac = new MusicAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Pulse
-                if (args[1].contains("Pulse")) {
-                    PulseAction ac = new PulseAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // ArmorStand Movement
-                if (args[1].equals("ArmorStand")) {
-                    // Show ArmorStand id action param
-                    String id = args[2];
-                    ShowStand stand = standmap.get(id);
-                    if (stand == null) {
-                        invalidLines.put(strLine, "No ArmorStand exists with the ID " + id);
-                        continue;
-                    }
-                    String action = args[3];
-                    switch (action.toLowerCase()) {
-                        case "spawn": {
-                            // x,y,z
-                            Location loc = WorldUtil.strToLocWithYaw(world.getName() + "," + args[4]);
-                            ArmorStandSpawn spawn = new ArmorStandSpawn(this, time, stand, loc);
-                            actions.add(spawn);
-                            break;
-                        }
-                        case "move": {
-                            // x,y,z speed
-                            Location loc = WorldUtil.strToLoc(world.getName() + "," + args[4]);
-                            double speed = Double.parseDouble(args[5]);
-                            ArmorStandMove move = new ArmorStandMove(this, time, stand, loc, speed);
-                            actions.add(move);
-                            break;
-                        }
-                        case "position": {
-                            // PositionType x,y,z time
-                            double speed = Double.parseDouble(args[6]);
-                            String[] alist = args[5].split(",");
-                            EulerAngle angle = new EulerAngle(rad(Double.parseDouble(alist[0])),
-                                    rad(Double.parseDouble(alist[1])), rad(Double.parseDouble(alist[2])));
-                            ArmorStandPosition position = new ArmorStandPosition(this, time, stand,
-                                    PositionType.fromString(args[4]), angle, speed);
-                            actions.add(position);
-                            break;
-                        }
-                        case "rotate": {
-                            // yaw speed
-                            float yaw = Float.parseFloat(args[4]);
-                            double speed = Double.parseDouble(args[5]);
-                            actions.add(new ArmorStandRotate(this, time, stand, yaw, speed));
-                            break;
-                        }
-                        case "despawn": {
-                            ArmorStandDespawn despawn = new ArmorStandDespawn(this, time, stand);
-                            actions.add(despawn);
-                            break;
-                        }
-                    }
-                    continue;
-                }
-                // Take away GWTS Hats
-                if (args[1].contains("GlowDone")) {
-                    actions.add(new GlowDoneAction(this, time));
-                    continue;
-                }
-                // Glow With The Show
-                if (args[1].contains("Glow")) {
-                    GlowAction ac = new GlowAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Lightning
-                if (args[1].contains("Lightning")) {
-                    LightningAction ac = new LightningAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // FakeBlock
-                if (args[1].contains("FakeBlock")) {
-                    FakeBlockAction ac = new FakeBlockAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Block
-                if (args[1].startsWith("Block")) {
-                    BlockAction ac = new BlockAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // PowerFirework
-                if (args[1].contains("PowerFirework")) {
-                    PowerFireworkAction ac = new PowerFireworkAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Firework
-                if (args[1].startsWith("Firework")) {
-                    FireworkAction ac = new FireworkAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Schematic
-                if (args[1].contains("Schematic")) {
-                    if (worldEditPlugin == null) {
-                        org.bukkit.plugin.Plugin plugin = Bukkit.getPluginManager().getPlugin("WorldEdit");
-                        if (plugin instanceof WorldEditPlugin) {
-                            worldEditPlugin = (WorldEditPlugin) plugin;
-                            terrainManager = new TerrainManager(worldEditPlugin, world);
-                        } else {
-                            throw new ShowParseException("Unable to load SchematicAction - no WorldEdit plugin found!");
-                        }
-                    }
-                    SchematicAction ac = new SchematicAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Fountain
-                if (args[1].contains("Fountain")) {
-                    FountainAction ac = new FountainAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Title
-                if (args[1].contains("Title")) {
-                    TitleAction ac = new TitleAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // ActionBar
-                if (args[1].contains("ActionBar")) {
-                    ActionBarAction ac = new ActionBarAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Command
-                if (args[1].contains("Command")) {
-                    CommandAction ac = new CommandAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // SpiralParticle
-                if (args[1].contains("SpiralParticle")) {
-                    SpiralParticle ac = new SpiralParticle(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Particle
-                if (args[1].contains("Particle")) {
-                    ParticleAction ac = new ParticleAction(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // AudioStart
-                if (args[1].contains("AudioStart")) {
-                    AudioStart ac = new AudioStart(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // AudioSync
-                if (args[1].contains("AudioSync")) {
-                    AudioSync ac = new AudioSync(this, time);
-                    actions.add(ac.load(strLine, args));
-                    continue;
-                }
-                // Sequences
-                if (args[1].contains("Sequence")) {
-                    ShowSequence sequence;
-                    switch (args[2].toLowerCase()) {
-                        case "laser": {
-                            sequence = new LaserSequence(this, time);
-                            break;
-                        }
-                        case "fountain": {
-                            sequence = new FountainSequence(this, time);
-                            break;
-                        }
-                        case "light": {
-                            sequence = new LightSequence(this, time);
-                            break;
-                        }
-                        case "particle": {
-                            sequence = new ParticleSequence(this, time);
-                            break;
-                        }
-                        case "build": {
-                            sequence = new BuildSequence(this, time);
-                            break;
-                        }
-                        default:
-                            continue;
-                    }
-                    sequences.add(sequence.load(strLine, args));
-                }
+                ShowAction action = parseAction(strLine, args, time, 1);
+                if (action != null) actions.add(action);
             }
             br.close();
             in.close();
@@ -421,6 +220,176 @@ public class Show {
         this.sequences = sequences;
         actions.forEach(this::addAction);
         actions.clear();
+    }
+
+    private ShowAction parseAction(String strLine, String[] args, long time, int start) throws ShowParseException {
+        ShowAction action;
+        if (args[start].contains("Text")) {
+            // Text
+            TextAction ac = new TextAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("Music")) {
+            // Music
+            MusicAction ac = new MusicAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("Pulse")) {
+            // Pulse
+            PulseAction ac = new PulseAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].equals("ArmorStand")) {
+            // ArmorStand Movement
+            // Show ArmorStand id action param
+            String id = args[start + 1];
+            ShowStand stand = standmap.get(id);
+            if (stand == null) {
+                invalidLines.put(strLine, "No ArmorStand exists with the ID " + id);
+                action = null;
+            } else {
+                String actionText = args[start + 2];
+                switch (actionText.toLowerCase()) {
+                    case "spawn": {
+                        // x,y,z
+                        Location loc = WorldUtil.strToLocWithYaw(world.getName() + "," + args[start + 3]);
+                        action = new ArmorStandSpawn(this, time, stand, loc);
+                        break;
+                    }
+                    case "move": {
+                        // x,y,z speed
+                        Location loc = WorldUtil.strToLoc(world.getName() + "," + args[start + 3]);
+                        double speed = Double.parseDouble(args[start + 4]);
+                        action = new ArmorStandMove(this, time, stand, loc, speed);
+                        break;
+                    }
+                    case "position": {
+                        // PositionType x,y,z time
+                        double speed = Double.parseDouble(args[start + 5]);
+                        String[] alist = args[start + 4].split(",");
+                        EulerAngle angle = new EulerAngle(rad(Double.parseDouble(alist[0])),
+                                rad(Double.parseDouble(alist[1])), rad(Double.parseDouble(alist[2])));
+                        action = new ArmorStandPosition(this, time, stand,
+                                PositionType.fromString(args[start + 3]), angle, speed);
+                        break;
+                    }
+                    case "rotate": {
+                        // yaw speed
+                        float yaw = Float.parseFloat(args[start + 3]);
+                        double speed = Double.parseDouble(args[start + 4]);
+                        action = new ArmorStandRotate(this, time, stand, yaw, speed);
+                        break;
+                    }
+                    case "despawn": {
+                        action = new ArmorStandDespawn(this, time, stand);
+                        break;
+                    }
+                    default:
+                        action = null;
+                }
+            }
+        } else if (args[start].contains("GlowDone")) {
+            // Take away GWTS Hats
+            action = new GlowDoneAction(this, time);
+        } else if (args[start].contains("Glow")) {
+            // Glow With The Show
+            GlowAction ac = new GlowAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("Lightning")) {
+            // Lightning
+            LightningAction ac = new LightningAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("FakeBlock")) {
+            // FakeBlock
+            FakeBlockAction ac = new FakeBlockAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].startsWith("Block")) {
+            // Block
+            BlockAction ac = new BlockAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("PowerFirework")) {
+            // PowerFirework
+            PowerFireworkAction ac = new PowerFireworkAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].startsWith("Firework")) {
+            // Firework
+            FireworkAction ac = new FireworkAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("Schematic")) {
+            // Schematic
+            if (worldEditPlugin == null) {
+                org.bukkit.plugin.Plugin plugin = Bukkit.getPluginManager().getPlugin("WorldEdit");
+                if (plugin instanceof WorldEditPlugin) {
+                    worldEditPlugin = (WorldEditPlugin) plugin;
+                    terrainManager = new TerrainManager(worldEditPlugin, world);
+                } else {
+                    throw new ShowParseException("Unable to load SchematicAction - no WorldEdit plugin found!");
+                }
+            }
+            SchematicAction ac = new SchematicAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("Fountain")) {
+            // Fountain
+            FountainAction ac = new FountainAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("Title")) {
+            // Title
+            TitleAction ac = new TitleAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("ActionBar")) {
+            // ActionBar
+            ActionBarAction ac = new ActionBarAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("Command")) {
+            // Command
+            CommandAction ac = new CommandAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("SpiralParticle")) {
+            // SpiralParticle
+            SpiralParticle ac = new SpiralParticle(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("Particle")) {
+            // Particle
+            ParticleAction ac = new ParticleAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("AudioStart")) {
+            // AudioStart
+            AudioStart ac = new AudioStart(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("AudioSync")) {
+            // AudioSync
+            AudioSync ac = new AudioSync(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[start].contains("Sequence")) {
+            // Sequences
+            ShowSequence sequence;
+            switch (args[start + 1].toLowerCase()) {
+                case "laser": {
+                    sequence = new LaserSequence(this, time);
+                    break;
+                }
+                case "fountain": {
+                    sequence = new FountainSequence(this, time);
+                    break;
+                }
+                case "light": {
+                    sequence = new LightSequence(this, time);
+                    break;
+                }
+                case "particle": {
+                    sequence = new ParticleSequence(this, time);
+                    break;
+                }
+                case "build": {
+                    sequence = new BuildSequence(this, time);
+                    break;
+                }
+                default:
+                    return null;
+            }
+            sequences.add(sequence.load(strLine, args));
+            action = null;
+        } else {
+            action = null;
+        }
+        return action;
     }
 
     private double rad(double v) {

--- a/src/main/java/network/palace/show/Show.java
+++ b/src/main/java/network/palace/show/Show.java
@@ -43,7 +43,7 @@ public class Show {
     @Getter private final World world;
     private Location location;
     @Getter private String name = "";
-    private LinkedList<ShowSequence> sequences;
+    @Getter private LinkedList<ShowSequence> sequences;
     @Getter private final long startTime;
     @Getter @Setter private long musicTime = 0;
     @Getter @Setter private String areaName = "none";
@@ -193,7 +193,7 @@ public class Show {
                 for (String timeStr : timeToks) {
                     time += (long) (Double.parseDouble(timeStr) * 1000);
                 }
-                ShowAction action = parseAction(strLine, args, time, 1);
+                ShowAction action = parseAction(strLine, args, time, sequences);
                 if (action != null) actions.add(action);
             }
             br.close();
@@ -222,58 +222,58 @@ public class Show {
         actions.clear();
     }
 
-    public ShowAction parseAction(String strLine, String[] args, long time, int start) throws ShowParseException {
+    public ShowAction parseAction(String strLine, String[] args, long time, LinkedList<ShowSequence> sequences) throws ShowParseException {
         ShowAction action;
-        if (args[start].contains("Text")) {
+        if (args[1].contains("Text")) {
             // Text
             TextAction ac = new TextAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("Music")) {
+        } else if (args[1].contains("Music")) {
             // Music
             MusicAction ac = new MusicAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("Pulse")) {
+        } else if (args[1].contains("Pulse")) {
             // Pulse
             PulseAction ac = new PulseAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].equals("ArmorStand")) {
+        } else if (args[1].equals("ArmorStand")) {
             // ArmorStand Movement
             // Show ArmorStand id action param
-            String id = args[start + 1];
+            String id = args[1 + 1];
             ShowStand stand = standmap.get(id);
             if (stand == null) {
                 invalidLines.put(strLine, "No ArmorStand exists with the ID " + id);
                 action = null;
             } else {
-                String actionText = args[start + 2];
+                String actionText = args[3];
                 switch (actionText.toLowerCase()) {
                     case "spawn": {
                         // x,y,z
-                        Location loc = WorldUtil.strToLocWithYaw(world.getName() + "," + args[start + 3]);
+                        Location loc = WorldUtil.strToLocWithYaw(world.getName() + "," + args[4]);
                         action = new ArmorStandSpawn(this, time, stand, loc);
                         break;
                     }
                     case "move": {
                         // x,y,z speed
-                        Location loc = WorldUtil.strToLoc(world.getName() + "," + args[start + 3]);
-                        double speed = Double.parseDouble(args[start + 4]);
+                        Location loc = WorldUtil.strToLoc(world.getName() + "," + args[4]);
+                        double speed = Double.parseDouble(args[5]);
                         action = new ArmorStandMove(this, time, stand, loc, speed);
                         break;
                     }
                     case "position": {
                         // PositionType x,y,z time
-                        double speed = Double.parseDouble(args[start + 5]);
-                        String[] alist = args[start + 4].split(",");
+                        double speed = Double.parseDouble(args[6]);
+                        String[] alist = args[5].split(",");
                         EulerAngle angle = new EulerAngle(rad(Double.parseDouble(alist[0])),
                                 rad(Double.parseDouble(alist[1])), rad(Double.parseDouble(alist[2])));
                         action = new ArmorStandPosition(this, time, stand,
-                                PositionType.fromString(args[start + 3]), angle, speed);
+                                PositionType.fromString(args[4]), angle, speed);
                         break;
                     }
                     case "rotate": {
                         // yaw speed
-                        float yaw = Float.parseFloat(args[start + 3]);
-                        double speed = Double.parseDouble(args[start + 4]);
+                        float yaw = Float.parseFloat(args[4]);
+                        double speed = Double.parseDouble(args[5]);
                         action = new ArmorStandRotate(this, time, stand, yaw, speed);
                         break;
                     }
@@ -285,34 +285,34 @@ public class Show {
                         action = null;
                 }
             }
-        } else if (args[start].contains("GlowDone")) {
+        } else if (args[1].contains("GlowDone")) {
             // Take away GWTS Hats
             action = new GlowDoneAction(this, time);
-        } else if (args[start].contains("Glow")) {
+        } else if (args[1].contains("Glow")) {
             // Glow With The Show
             GlowAction ac = new GlowAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("Lightning")) {
+        } else if (args[1].contains("Lightning")) {
             // Lightning
             LightningAction ac = new LightningAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("FakeBlock")) {
+        } else if (args[1].contains("FakeBlock")) {
             // FakeBlock
             FakeBlockAction ac = new FakeBlockAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].startsWith("Block")) {
+        } else if (args[1].startsWith("Block")) {
             // Block
             BlockAction ac = new BlockAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("PowerFirework")) {
+        } else if (args[1].contains("PowerFirework")) {
             // PowerFirework
             PowerFireworkAction ac = new PowerFireworkAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].startsWith("Firework")) {
+        } else if (args[1].startsWith("Firework")) {
             // Firework
             FireworkAction ac = new FireworkAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("Schematic")) {
+        } else if (args[1].contains("Schematic")) {
             // Schematic
             if (worldEditPlugin == null) {
                 org.bukkit.plugin.Plugin plugin = Bukkit.getPluginManager().getPlugin("WorldEdit");
@@ -325,42 +325,46 @@ public class Show {
             }
             SchematicAction ac = new SchematicAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("Fountain")) {
+        } else if (args[1].contains("Fountain")) {
             // Fountain
             FountainAction ac = new FountainAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("Title")) {
+        } else if (args[1].contains("Title")) {
             // Title
             TitleAction ac = new TitleAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("ActionBar")) {
+        } else if (args[1].contains("ActionBar")) {
             // ActionBar
             ActionBarAction ac = new ActionBarAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("Command")) {
+        } else if (args[1].contains("Command")) {
             // Command
             CommandAction ac = new CommandAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("SpiralParticle")) {
+        } else if (args[1].contains("Repeat")) {
+            // Repeat
+            RepeatAction ac = new RepeatAction(this, time);
+            action = ac.load(strLine, args);
+        } else if (args[1].contains("SpiralParticle")) {
             // SpiralParticle
             SpiralParticle ac = new SpiralParticle(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("Particle")) {
+        } else if (args[1].contains("Particle")) {
             // Particle
             ParticleAction ac = new ParticleAction(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("AudioStart")) {
+        } else if (args[1].contains("AudioStart")) {
             // AudioStart
             AudioStart ac = new AudioStart(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("AudioSync")) {
+        } else if (args[1].contains("AudioSync")) {
             // AudioSync
             AudioSync ac = new AudioSync(this, time);
             action = ac.load(strLine, args);
-        } else if (args[start].contains("Sequence")) {
+        } else if (args[1].contains("Sequence")) {
             // Sequences
             ShowSequence sequence;
-            switch (args[start + 1].toLowerCase()) {
+            switch (args[1 + 1].toLowerCase()) {
                 case "laser": {
                     sequence = new LaserSequence(this, time);
                     break;
@@ -384,7 +388,7 @@ public class Show {
                 default:
                     return null;
             }
-            sequences.add(sequence.load(strLine, args));
+            if (sequence != null) sequences.add(sequence.load(strLine, args));
             action = null;
         } else {
             action = null;
@@ -501,9 +505,7 @@ public class Show {
             try {
                 if (timeDiff < action.getTime()) continue;
                 try {
-                    if (!action.play(nearPlayers)) continue;
-                    // If false, it needs to continue being run
-                    // If true, it will continue down to be removed from the list of actions
+                    action.play(nearPlayers);
                 } catch (Exception e) {
                     Core.logMessage("Show " + action.getShow().getName(), "Error playing action in show " + action.getShow().getName());
                 }

--- a/src/main/java/network/palace/show/actions/ActionBarAction.java
+++ b/src/main/java/network/palace/show/actions/ActionBarAction.java
@@ -13,13 +13,14 @@ public class ActionBarAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         for (CPlayer player : nearPlayers) {
             if (player == null) continue;
             if (Show.offset(player.getLocation(), show.getLocation()) < show.getRadius()) {
                 player.getActionBar().show(text);
             }
         }
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/ActionBarAction.java
+++ b/src/main/java/network/palace/show/actions/ActionBarAction.java
@@ -12,15 +12,19 @@ public class ActionBarAction extends ShowAction {
         super(show, time);
     }
 
+    public ActionBarAction(Show show, long time, String text) {
+        super(show, time);
+        this.text = text;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         for (CPlayer player : nearPlayers) {
             if (player == null) continue;
             if (Show.offset(player.getLocation(), show.getLocation()) < show.getRadius()) {
                 player.getActionBar().show(text);
             }
         }
-        return true;
     }
 
     @Override
@@ -31,5 +35,10 @@ public class ActionBarAction extends ShowAction {
         if (text.length() > 1) text = new StringBuilder(text.substring(0, text.length() - 1));
         this.text = ChatColor.translateAlternateColorCodes('&', text.toString());
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new ActionBarAction(show, time, text);
     }
 }

--- a/src/main/java/network/palace/show/actions/BlockAction.java
+++ b/src/main/java/network/palace/show/actions/BlockAction.java
@@ -27,10 +27,11 @@ public class BlockAction extends ShowAction {
 
     @SuppressWarnings("deprecation")
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         Block block = location.getBlock();
         block.setTypeId(type);
         block.setData(data);
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/BlockAction.java
+++ b/src/main/java/network/palace/show/actions/BlockAction.java
@@ -27,11 +27,10 @@ public class BlockAction extends ShowAction {
 
     @SuppressWarnings("deprecation")
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         Block block = location.getBlock();
         block.setTypeId(type);
         block.setData(data);
-        return true;
     }
 
     @Override
@@ -49,5 +48,10 @@ public class BlockAction extends ShowAction {
             throw new ShowParseException(e.getReason());
         }
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new BlockAction(show, time, location, type, data);
     }
 }

--- a/src/main/java/network/palace/show/actions/CommandAction.java
+++ b/src/main/java/network/palace/show/actions/CommandAction.java
@@ -13,8 +13,9 @@ public class CommandAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/CommandAction.java
+++ b/src/main/java/network/palace/show/actions/CommandAction.java
@@ -12,10 +12,14 @@ public class CommandAction extends ShowAction {
         super(show, time);
     }
 
+    public CommandAction(Show show, long time, String command) {
+        super(show, time);
+        this.command = command;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
-        return true;
     }
 
     @Override
@@ -26,5 +30,10 @@ public class CommandAction extends ShowAction {
         if (text.length() > 1) text = new StringBuilder(text.substring(0, text.length() - 1));
         this.command = text.toString();
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new CommandAction(show, time, command);
     }
 }

--- a/src/main/java/network/palace/show/actions/FakeBlockAction.java
+++ b/src/main/java/network/palace/show/actions/FakeBlockAction.java
@@ -32,7 +32,7 @@ public class FakeBlockAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         try {
             WrapperPlayServerBlockChange p = new WrapperPlayServerBlockChange();
             p.setLocation(new BlockPosition(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
@@ -46,6 +46,7 @@ public class FakeBlockAction extends ShowAction {
                     time + " for show " + show.getName());
             e.printStackTrace();
         }
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/FakeBlockAction.java
+++ b/src/main/java/network/palace/show/actions/FakeBlockAction.java
@@ -31,8 +31,15 @@ public class FakeBlockAction extends ShowAction {
         super(show, time);
     }
 
+    public FakeBlockAction(Show show, long time, Location loc, int id, byte data) {
+        super(show, time);
+        this.loc = loc;
+        this.id = id;
+        this.data = data;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         try {
             WrapperPlayServerBlockChange p = new WrapperPlayServerBlockChange();
             p.setLocation(new BlockPosition(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
@@ -46,7 +53,6 @@ public class FakeBlockAction extends ShowAction {
                     time + " for show " + show.getName());
             e.printStackTrace();
         }
-        return true;
     }
 
     @Override
@@ -64,5 +70,10 @@ public class FakeBlockAction extends ShowAction {
             throw new ShowParseException(e.getReason());
         }
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new FakeBlockAction(show, time, loc, id, data);
     }
 }

--- a/src/main/java/network/palace/show/actions/FireworkAction.java
+++ b/src/main/java/network/palace/show/actions/FireworkAction.java
@@ -24,14 +24,22 @@ public class FireworkAction extends ShowAction implements Listener {
         super(show, time);
     }
 
+    public FireworkAction(Show show, long time, Location loc, ArrayList<FireworkEffect> effects, int power, Vector direction, double dirPower) {
+        super(show, time);
+        this.loc = loc;
+        this.effects = effects;
+        this.power = power;
+        this.direction = direction;
+        this.dirPower = dirPower;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         try {
             playFirework();
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return true;
     }
 
     public void playFirework() throws Exception {
@@ -119,5 +127,10 @@ public class FireworkAction extends ShowAction implements Listener {
         this.direction = dir;
         this.dirPower = dirPower;
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new FireworkAction(show, time, loc, effects, power, direction, dirPower);
     }
 }

--- a/src/main/java/network/palace/show/actions/FireworkAction.java
+++ b/src/main/java/network/palace/show/actions/FireworkAction.java
@@ -25,12 +25,13 @@ public class FireworkAction extends ShowAction implements Listener {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         try {
             playFirework();
         } catch (Exception e) {
             e.printStackTrace();
         }
+        return true;
     }
 
     public void playFirework() throws Exception {
@@ -56,7 +57,7 @@ public class FireworkAction extends ShowAction implements Listener {
             fw.setVelocity(direction.normalize().multiply(dirPower * 0.05));
         }
         if (instaburst) {
-            show.addLaterAction(new FireworkExplodeAction(show, time + 50, fw));
+            show.addLaterAction(new FireworkExplodeAction(show, show.getShowTime() + 50, fw));
         }
     }
 

--- a/src/main/java/network/palace/show/actions/FireworkExplodeAction.java
+++ b/src/main/java/network/palace/show/actions/FireworkExplodeAction.java
@@ -17,13 +17,17 @@ public class FireworkExplodeAction extends ShowAction {
     }
 
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         fw.detonate();
-        return true;
     }
 
     @Override
     public ShowAction load(String line, String... args) throws ShowParseException {
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new FireworkExplodeAction(show, time, fw);
     }
 }

--- a/src/main/java/network/palace/show/actions/FireworkExplodeAction.java
+++ b/src/main/java/network/palace/show/actions/FireworkExplodeAction.java
@@ -17,8 +17,9 @@ public class FireworkExplodeAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         fw.detonate();
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/FountainAction.java
+++ b/src/main/java/network/palace/show/actions/FountainAction.java
@@ -23,8 +23,9 @@ public class FountainAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         ShowPlugin.getInstance().getFountainManager().addFountain(new Fountain(loc, duration, type, data, force));
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/FountainAction.java
+++ b/src/main/java/network/palace/show/actions/FountainAction.java
@@ -22,10 +22,18 @@ public class FountainAction extends ShowAction {
         super(show, time);
     }
 
+    public FountainAction(Show show, long time, double duration, Location loc, int type, byte data, Vector force) {
+        super(show, time);
+        this.duration = duration;
+        this.loc = loc;
+        this.type = type;
+        this.data = data;
+        this.force = force;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         ShowPlugin.getInstance().getFountainManager().addFountain(new Fountain(loc, duration, type, data, force));
-        return true;
     }
 
     @Override
@@ -45,5 +53,10 @@ public class FountainAction extends ShowAction {
             throw new ShowParseException(e.getReason());
         }
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new FountainAction(show, time, duration, loc, type, data, force);
     }
 }

--- a/src/main/java/network/palace/show/actions/GlowAction.java
+++ b/src/main/java/network/palace/show/actions/GlowAction.java
@@ -35,8 +35,15 @@ public class GlowAction extends ShowAction {
         helm = new ItemStack(Material.LEATHER_HELMET);
     }
 
+    public GlowAction(Show show, long time, int radius, ItemStack helm, Location loc) {
+        super(show, time);
+        this.radius = radius;
+        this.helm = helm;
+        this.loc = loc;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         List<AbstractPacket> packets = new ArrayList<>();
         WrapperPlayServerEntityEquipment p = new WrapperPlayServerEntityEquipment();
         p.setSlot(EnumWrappers.ItemSlot.HEAD);
@@ -49,7 +56,6 @@ public class GlowAction extends ShowAction {
                     p.setEntityID(tp.getEntityId());
                     tp.sendPacket(p);
                 });
-        return true;
     }
 
     @Override
@@ -80,5 +86,10 @@ public class GlowAction extends ShowAction {
             throw new ShowParseException("Invalid Glow Line");
         }
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new GlowAction(show, time, radius, helm, loc);
     }
 }

--- a/src/main/java/network/palace/show/actions/GlowAction.java
+++ b/src/main/java/network/palace/show/actions/GlowAction.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 public class GlowAction extends ShowAction {
     public static String name = ChatColor.LIGHT_PURPLE + "Glow With The Show Ears";
     private int radius;
-    private ItemStack helm;
+    private final ItemStack helm;
     private Location loc;
 
     public GlowAction(Show show, long time) {
@@ -36,7 +36,7 @@ public class GlowAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         List<AbstractPacket> packets = new ArrayList<>();
         WrapperPlayServerEntityEquipment p = new WrapperPlayServerEntityEquipment();
         p.setSlot(EnumWrappers.ItemSlot.HEAD);
@@ -49,6 +49,7 @@ public class GlowAction extends ShowAction {
                     p.setEntityID(tp.getEntityId());
                     tp.sendPacket(p);
                 });
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/GlowDoneAction.java
+++ b/src/main/java/network/palace/show/actions/GlowDoneAction.java
@@ -19,17 +19,21 @@ public class GlowDoneAction extends ShowAction {
     }
 
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         ItemStack air = new ItemStack(Material.AIR);
         for (Player tp : Bukkit.getOnlinePlayers()) {
             tp.getInventory().setHelmet(air);
         }
         new GlowDoneEvent(show).call();
-        return true;
     }
 
     @Override
     public ShowAction load(String line, String... args) throws ShowParseException {
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new GlowDoneAction(show, time);
     }
 }

--- a/src/main/java/network/palace/show/actions/GlowDoneAction.java
+++ b/src/main/java/network/palace/show/actions/GlowDoneAction.java
@@ -19,12 +19,13 @@ public class GlowDoneAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         ItemStack air = new ItemStack(Material.AIR);
         for (Player tp : Bukkit.getOnlinePlayers()) {
             tp.getInventory().setHelmet(air);
         }
         new GlowDoneEvent(show).call();
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/LightningAction.java
+++ b/src/main/java/network/palace/show/actions/LightningAction.java
@@ -15,8 +15,9 @@ public class LightningAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         loc.getWorld().strikeLightningEffect(loc);
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/LightningAction.java
+++ b/src/main/java/network/palace/show/actions/LightningAction.java
@@ -1,6 +1,5 @@
 package network.palace.show.actions;
 
-
 import network.palace.core.player.CPlayer;
 import network.palace.show.Show;
 import network.palace.show.exceptions.ShowParseException;
@@ -14,10 +13,14 @@ public class LightningAction extends ShowAction {
         super(show, time);
     }
 
+    public LightningAction(Show show, long time, Location loc) {
+        super(show, time);
+        this.loc = loc;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         loc.getWorld().strikeLightningEffect(loc);
-        return true;
     }
 
     @Override
@@ -27,5 +30,10 @@ public class LightningAction extends ShowAction {
             throw new ShowParseException("Invalid Location");
         }
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new LightningAction(show, time, loc);
     }
 }

--- a/src/main/java/network/palace/show/actions/MusicAction.java
+++ b/src/main/java/network/palace/show/actions/MusicAction.java
@@ -12,8 +12,9 @@ public class MusicAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         show.playMusic(record);
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/MusicAction.java
+++ b/src/main/java/network/palace/show/actions/MusicAction.java
@@ -11,10 +11,14 @@ public class MusicAction extends ShowAction {
         super(show, time);
     }
 
+    public MusicAction(Show show, long time, int record) {
+        super(show, time);
+        this.record = record;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         show.playMusic(record);
-        return true;
     }
 
     @Override
@@ -25,5 +29,10 @@ public class MusicAction extends ShowAction {
             throw new ShowParseException("Invalid Material");
         }
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new MusicAction(show, time, record);
     }
 }

--- a/src/main/java/network/palace/show/actions/ParticleAction.java
+++ b/src/main/java/network/palace/show/actions/ParticleAction.java
@@ -25,14 +25,15 @@ public class ParticleAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         if (effect == null) {
-            return;
+            return true;
         }
         for (CPlayer tp : nearPlayers) {
             if (tp == null) continue;
             tp.getParticles().send(loc, effect, amount, (float) offsetX, (float) offsetY, (float) offsetZ, speed);
         }
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/ParticleAction.java
+++ b/src/main/java/network/palace/show/actions/ParticleAction.java
@@ -24,16 +24,24 @@ public class ParticleAction extends ShowAction {
         super(show, time);
     }
 
+    public ParticleAction(Show show, long time, Particle effect, Location loc, double offsetX, double offsetY, double offsetZ, float speed, int amount) {
+        super(show, time);
+        this.effect = effect;
+        this.loc = loc;
+        this.offsetX = offsetX;
+        this.offsetY = offsetY;
+        this.offsetZ = offsetZ;
+        this.speed = speed;
+        this.amount = amount;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
-        if (effect == null) {
-            return true;
-        }
+    public void play(CPlayer[] nearPlayers) {
+        if (effect == null) return;
         for (CPlayer tp : nearPlayers) {
             if (tp == null) continue;
             tp.getParticles().send(loc, effect, amount, (float) offsetX, (float) offsetY, (float) offsetZ, speed);
         }
-        return true;
     }
 
     @Override
@@ -47,5 +55,10 @@ public class ParticleAction extends ShowAction {
         this.speed = Float.parseFloat(args[7]);
         this.amount = Integer.parseInt(args[8]);
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new ParticleAction(show, time, effect, loc, offsetX, offsetY, offsetZ, speed, amount);
     }
 }

--- a/src/main/java/network/palace/show/actions/PowerFireworkAction.java
+++ b/src/main/java/network/palace/show/actions/PowerFireworkAction.java
@@ -25,8 +25,15 @@ public class PowerFireworkAction extends ShowAction {
         super(show, time);
     }
 
+    public PowerFireworkAction(Show show, long time, Location loc, Vector motion, List<FireworkEffect> effects) {
+        super(show, time);
+        this.loc = loc;
+        this.motion = motion;
+        this.effects = effects;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         Firework fw = loc.getWorld().spawn(loc, Firework.class);
         FireworkMeta meta = fw.getFireworkMeta();
         for (FireworkEffect effect : effects) {
@@ -35,7 +42,6 @@ public class PowerFireworkAction extends ShowAction {
         fw.setFireworkMeta(meta);
         fw.setVelocity(motion);
         show.addLaterAction(new FireworkExplodeAction(show, show.getShowTime() + 1, fw));
-        return true;
     }
 
     @Override
@@ -61,5 +67,10 @@ public class PowerFireworkAction extends ShowAction {
         this.motion = motion;
         this.effects = effectList;
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new PowerFireworkAction(show, time, loc, motion, effects);
     }
 }

--- a/src/main/java/network/palace/show/actions/PowerFireworkAction.java
+++ b/src/main/java/network/palace/show/actions/PowerFireworkAction.java
@@ -26,7 +26,7 @@ public class PowerFireworkAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         Firework fw = loc.getWorld().spawn(loc, Firework.class);
         FireworkMeta meta = fw.getFireworkMeta();
         for (FireworkEffect effect : effects) {
@@ -34,7 +34,8 @@ public class PowerFireworkAction extends ShowAction {
         }
         fw.setFireworkMeta(meta);
         fw.setVelocity(motion);
-        show.addLaterAction(new FireworkExplodeAction(show, time + 1, fw));
+        show.addLaterAction(new FireworkExplodeAction(show, show.getShowTime() + 1, fw));
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/PulseAction.java
+++ b/src/main/java/network/palace/show/actions/PulseAction.java
@@ -15,15 +15,19 @@ public class PulseAction extends ShowAction {
         super(show, time);
     }
 
+    public PulseAction(Show show, long time, Location loc) {
+        super(show, time);
+        this.loc = loc;
+    }
+
     @SuppressWarnings("deprecation")
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         Block pre = loc.getBlock();
         final int id = pre.getTypeId();
         final byte data = pre.getData();
         loc.getBlock().setType(Material.REDSTONE_BLOCK);
         show.addLaterAction(new BlockAction(show, show.getShowTime() + 100, loc, id, data));
-        return true;
     }
 
     @Override
@@ -33,5 +37,10 @@ public class PulseAction extends ShowAction {
             throw new ShowParseException("Invalid Location");
         }
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new PulseAction(show, time, loc);
     }
 }

--- a/src/main/java/network/palace/show/actions/PulseAction.java
+++ b/src/main/java/network/palace/show/actions/PulseAction.java
@@ -17,12 +17,13 @@ public class PulseAction extends ShowAction {
 
     @SuppressWarnings("deprecation")
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         Block pre = loc.getBlock();
         final int id = pre.getTypeId();
         final byte data = pre.getData();
         loc.getBlock().setType(Material.REDSTONE_BLOCK);
-        show.addLaterAction(new BlockAction(show, time + 100, loc, id, data));
+        show.addLaterAction(new BlockAction(show, show.getShowTime() + 100, loc, id, data));
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/RepeatAction.java
+++ b/src/main/java/network/palace/show/actions/RepeatAction.java
@@ -34,6 +34,8 @@ public class RepeatAction extends ShowAction {
         // 0 Repeat occurrences interval ActionText
         this.occurrences = Integer.parseInt(args[2]);
         this.interval = Integer.parseInt(args[3]);
+        if (occurrences < 1) throw new ShowParseException("'occurrences' value in Repeat action must be at least 1");
+        if (interval < 1) throw new ShowParseException("'interval' value in Repeat action must be at least 1");
         StringBuilder action = new StringBuilder("0\t");
         for (int i = 4; i < args.length; i++) {
             action.append(args[i]).append("\t");

--- a/src/main/java/network/palace/show/actions/RepeatAction.java
+++ b/src/main/java/network/palace/show/actions/RepeatAction.java
@@ -3,40 +3,49 @@ package network.palace.show.actions;
 import network.palace.core.player.CPlayer;
 import network.palace.show.Show;
 import network.palace.show.exceptions.ShowParseException;
+import network.palace.show.utils.ShowUtil;
+
+import java.util.Arrays;
 
 public class RepeatAction extends ShowAction {
     private ShowAction repeatingAction;
-    private int actionCounter; // decreases to 0 until it has been run the number of times it needs to
-    private int intervalCounter; // increases from 0 until it is equal to 'interval'
-    private int interval; // the number of ticks between each run
-    private boolean first = true;
+    private int occurrences;
+    private int interval;
 
     public RepeatAction(Show show, long time) {
         super(show, time);
     }
 
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
-        if (actionCounter > 0) {
-            // still have a number of runs left, run it
-            if (!first && intervalCounter < interval) {
-                intervalCounter++;
-                return false;
+    public void play(CPlayer[] nearPlayers) {
+        for (int i = 0; i < occurrences; i++) {
+            try {
+                ShowAction copy = repeatingAction.copy(show, time + ((long) interval * 50 * i));
+                show.addLaterAction(copy);
+            } catch (ShowParseException e) {
+                ShowUtil.logDebug(show.getName(), "Error parsing Repeat action: " + e.getMessage());
+                e.printStackTrace();
             }
-            first = false;
-            intervalCounter = 0;
-            repeatingAction.play(nearPlayers);
-            return --actionCounter <= 0; // return true if actionCounter <= 0 after being decreased, else return false
         }
-        return true;
     }
 
     @Override
     public ShowAction load(String line, String... args) throws ShowParseException {
-        // 0 Repeat actionCounter interval ActionText
-        this.actionCounter = Integer.parseInt(args[2]);
+        // 0 Repeat occurrences interval ActionText
+        this.occurrences = Integer.parseInt(args[2]);
         this.interval = Integer.parseInt(args[3]);
-        this.repeatingAction = show.parseAction(line, args, 0, 4);
+        StringBuilder action = new StringBuilder("0\t");
+        for (int i = 4; i < args.length; i++) {
+            action.append(args[i]).append("\t");
+        }
+        String[] newArgs = Arrays.copyOfRange(args, 3, args.length);
+        newArgs[0] = "0";
+        this.repeatingAction = show.parseAction(action.toString(), newArgs, 0, show.getSequences());
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        throw new ShowParseException("You cannot stack Repeat actions!");
     }
 }

--- a/src/main/java/network/palace/show/actions/RepeatAction.java
+++ b/src/main/java/network/palace/show/actions/RepeatAction.java
@@ -1,0 +1,42 @@
+package network.palace.show.actions;
+
+import network.palace.core.player.CPlayer;
+import network.palace.show.Show;
+import network.palace.show.exceptions.ShowParseException;
+
+public class RepeatAction extends ShowAction {
+    private ShowAction repeatingAction;
+    private int actionCounter; // decreases to 0 until it has been run the number of times it needs to
+    private int intervalCounter; // increases from 0 until it is equal to 'interval'
+    private int interval; // the number of ticks between each run
+    private boolean first = true;
+
+    public RepeatAction(Show show, long time) {
+        super(show, time);
+    }
+
+    @Override
+    public boolean play(CPlayer[] nearPlayers) {
+        if (actionCounter > 0) {
+            // still have a number of runs left, run it
+            if (!first && intervalCounter < interval) {
+                intervalCounter++;
+                return false;
+            }
+            first = false;
+            intervalCounter = 0;
+            repeatingAction.play(nearPlayers);
+            return --actionCounter <= 0; // return true if actionCounter <= 0 after being decreased, else return false
+        }
+        return true;
+    }
+
+    @Override
+    public ShowAction load(String line, String... args) throws ShowParseException {
+        // 0 Repeat actionCounter interval ActionText
+        this.actionCounter = Integer.parseInt(args[2]);
+        this.interval = Integer.parseInt(args[3]);
+        this.repeatingAction = show.parseAction(line, args, 0, 4);
+        return this;
+    }
+}

--- a/src/main/java/network/palace/show/actions/SchematicAction.java
+++ b/src/main/java/network/palace/show/actions/SchematicAction.java
@@ -17,12 +17,13 @@ public class SchematicAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         try {
             show.getTerrainManager().loadSchematic(show.getWorldEditPlugin(), fname, loc, noAir);
         } catch (Exception e) {
             e.printStackTrace();
         }
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/SchematicAction.java
+++ b/src/main/java/network/palace/show/actions/SchematicAction.java
@@ -16,14 +16,20 @@ public class SchematicAction extends ShowAction {
         super(show, time);
     }
 
+    public SchematicAction(Show show, long time, Location loc, String fname, boolean noAir) {
+        super(show, time);
+        this.loc = loc;
+        this.fname = fname;
+        this.noAir = noAir;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         try {
             show.getTerrainManager().loadSchematic(show.getWorldEditPlugin(), fname, loc, noAir);
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return true;
     }
 
     @Override
@@ -46,5 +52,10 @@ public class SchematicAction extends ShowAction {
             throw new ShowParseException("Invalid X, Y, or Z Coordinates!");
         }
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new SchematicAction(show, time, loc, fname, noAir);
     }
 }

--- a/src/main/java/network/palace/show/actions/ShowAction.java
+++ b/src/main/java/network/palace/show/actions/ShowAction.java
@@ -18,7 +18,7 @@ public abstract class ShowAction {
         this.time = time;
     }
 
-    public abstract void play(CPlayer[] nearPlayers);
+    public abstract boolean play(CPlayer[] nearPlayers);
 
     public abstract ShowAction load(String line, String... args) throws ShowParseException;
 }

--- a/src/main/java/network/palace/show/actions/ShowAction.java
+++ b/src/main/java/network/palace/show/actions/ShowAction.java
@@ -18,7 +18,9 @@ public abstract class ShowAction {
         this.time = time;
     }
 
-    public abstract boolean play(CPlayer[] nearPlayers);
+    public abstract void play(CPlayer[] nearPlayers);
 
     public abstract ShowAction load(String line, String... args) throws ShowParseException;
+
+    protected abstract ShowAction copy(Show show, long time) throws ShowParseException;
 }

--- a/src/main/java/network/palace/show/actions/SpiralParticle.java
+++ b/src/main/java/network/palace/show/actions/SpiralParticle.java
@@ -26,7 +26,7 @@ public class SpiralParticle extends ShowAction {
     }
 
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         int taskID = Core.runTaskTimer(() -> {
             for (int i = 1; i <= strands; i++) {
                 for (int j = 1; j <= particles; j++) {
@@ -56,7 +56,6 @@ public class SpiralParticle extends ShowAction {
             step += speed;
         }, 0L, 1L);
         Core.runTaskLater(() -> Core.cancelTask(taskID), duration * 20L);
-        return true;
     }
 
     @Override
@@ -74,5 +73,10 @@ public class SpiralParticle extends ShowAction {
             this.speed = Double.parseDouble(args[10]);
         }
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        throw new ShowParseException("This action doesn't support repeating!");
     }
 }

--- a/src/main/java/network/palace/show/actions/SpiralParticle.java
+++ b/src/main/java/network/palace/show/actions/SpiralParticle.java
@@ -26,7 +26,7 @@ public class SpiralParticle extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         int taskID = Core.runTaskTimer(() -> {
             for (int i = 1; i <= strands; i++) {
                 for (int j = 1; j <= particles; j++) {
@@ -55,7 +55,8 @@ public class SpiralParticle extends ShowAction {
             }
             step += speed;
         }, 0L, 1L);
-        Core.runTaskLater(() -> Core.cancelTask(taskID), duration * 20);
+        Core.runTaskLater(() -> Core.cancelTask(taskID), duration * 20L);
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/TextAction.java
+++ b/src/main/java/network/palace/show/actions/TextAction.java
@@ -12,8 +12,9 @@ public class TextAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         show.displayText(text);
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/TextAction.java
+++ b/src/main/java/network/palace/show/actions/TextAction.java
@@ -11,10 +11,14 @@ public class TextAction extends ShowAction {
         super(show, time);
     }
 
+    public TextAction(Show show, long time, String text) {
+        super(show, time);
+        this.text = text;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         show.displayText(text);
-        return true;
     }
 
     @Override
@@ -26,5 +30,10 @@ public class TextAction extends ShowAction {
             text = new StringBuilder(text.substring(0, text.length() - 1));
         this.text = text.toString();
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new TextAction(show, time, text);
     }
 }

--- a/src/main/java/network/palace/show/actions/TitleAction.java
+++ b/src/main/java/network/palace/show/actions/TitleAction.java
@@ -21,8 +21,17 @@ public class TitleAction extends ShowAction {
         super(show, time);
     }
 
+    public TitleAction(Show show, long time, TitleType type, String title, int fadeIn, int stay, int fadeOut) {
+        super(show, time);
+        this.type = type;
+        this.title = title;
+        this.fadeIn = fadeIn;
+        this.stay = stay;
+        this.fadeOut = fadeOut;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         for (CPlayer player : nearPlayers) {
             if (player == null) continue;
             if (Show.offset(player.getLocation(), show.getLocation()) < show.getRadius()) {
@@ -33,7 +42,6 @@ public class TitleAction extends ShowAction {
                 }
             }
         }
-        return true;
     }
 
     @Override
@@ -52,5 +60,10 @@ public class TitleAction extends ShowAction {
         this.fadeOut = fadeOut;
         this.stay = stay;
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new TitleAction(show, time, type, title, fadeIn, stay, fadeOut);
     }
 }

--- a/src/main/java/network/palace/show/actions/TitleAction.java
+++ b/src/main/java/network/palace/show/actions/TitleAction.java
@@ -22,7 +22,7 @@ public class TitleAction extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         for (CPlayer player : nearPlayers) {
             if (player == null) continue;
             if (Show.offset(player.getLocation(), show.getLocation()) < show.getRadius()) {
@@ -33,6 +33,7 @@ public class TitleAction extends ShowAction {
                 }
             }
         }
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/armor/ArmorStandDespawn.java
+++ b/src/main/java/network/palace/show/actions/armor/ArmorStandDespawn.java
@@ -20,20 +20,24 @@ public class ArmorStandDespawn extends ShowAction {
     }
 
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         if (!stand.isHasSpawned()) {
             ShowUtil.logDebug(show.getName(), "ArmorStand with ID " + stand.getId() + " has not spawned");
-            return true;
+            return;
         }
         ArmorStand armor = stand.getStand();
         armor.remove();
         stand.setStand(null);
         stand.despawn();
-        return true;
     }
 
     @Override
     public ShowAction load(String line, String... args) throws ShowParseException {
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new ArmorStandDespawn(show, time, stand);
     }
 }

--- a/src/main/java/network/palace/show/actions/armor/ArmorStandDespawn.java
+++ b/src/main/java/network/palace/show/actions/armor/ArmorStandDespawn.java
@@ -12,7 +12,7 @@ import org.bukkit.entity.ArmorStand;
  * Created by Marc on 10/11/15
  */
 public class ArmorStandDespawn extends ShowAction {
-    private ShowStand stand;
+    private final ShowStand stand;
 
     public ArmorStandDespawn(Show show, long time, ShowStand stand) {
         super(show, time);
@@ -20,15 +20,16 @@ public class ArmorStandDespawn extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         if (!stand.isHasSpawned()) {
             ShowUtil.logDebug(show.getName(), "ArmorStand with ID " + stand.getId() + " has not spawned");
-            return;
+            return true;
         }
         ArmorStand armor = stand.getStand();
         armor.remove();
         stand.setStand(null);
         stand.despawn();
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/armor/ArmorStandMove.java
+++ b/src/main/java/network/palace/show/actions/armor/ArmorStandMove.java
@@ -16,8 +16,8 @@ import org.bukkit.util.Vector;
  * Created by Marc on 10/11/15
  */
 public class ArmorStandMove extends ShowAction {
-    private final Location loc;
     private final ShowStand stand;
+    private final Location loc;
     private final double speed;
 
     public ArmorStandMove(Show show, long time, ShowStand stand, Location loc, double speed) {
@@ -28,14 +28,14 @@ public class ArmorStandMove extends ShowAction {
     }
 
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         if (!stand.isHasSpawned()) {
             ShowUtil.logDebug(show.getName(), "ArmorStand with ID " + stand.getId() + " has not spawned");
-            return true;
+            return;
         }
         Location l = stand.getStand().getLocation();
         if (loc == null || l == null) {
-            return true;
+            return;
         }
         double x = ((float) (((float) (loc.getX() - l.getX())) / (20 * speed)));
         double y = ((float) (((float) (loc.getY() - l.getY())) / (20 * speed)));
@@ -43,11 +43,15 @@ public class ArmorStandMove extends ShowAction {
         Vector motion = new Vector(x, y, z);
         stand.setMovement(new Movement(motion, speed * 20));
         ShowPlugin.getInstance().getArmorStandManager().addStand(stand, StandAction.MOVE);
-        return true;
     }
 
     @Override
     public ShowAction load(String line, String... args) throws ShowParseException {
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new ArmorStandMove(show, time, stand, loc, speed);
     }
 }

--- a/src/main/java/network/palace/show/actions/armor/ArmorStandMove.java
+++ b/src/main/java/network/palace/show/actions/armor/ArmorStandMove.java
@@ -9,7 +9,6 @@ import network.palace.show.handlers.armorstand.Movement;
 import network.palace.show.handlers.armorstand.ShowStand;
 import network.palace.show.handlers.armorstand.StandAction;
 import network.palace.show.utils.ShowUtil;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 
@@ -18,8 +17,8 @@ import org.bukkit.util.Vector;
  */
 public class ArmorStandMove extends ShowAction {
     private final Location loc;
-    private ShowStand stand;
-    private double speed;
+    private final ShowStand stand;
+    private final double speed;
 
     public ArmorStandMove(Show show, long time, ShowStand stand, Location loc, double speed) {
         super(show, time);
@@ -29,14 +28,14 @@ public class ArmorStandMove extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         if (!stand.isHasSpawned()) {
             ShowUtil.logDebug(show.getName(), "ArmorStand with ID " + stand.getId() + " has not spawned");
-            return;
+            return true;
         }
         Location l = stand.getStand().getLocation();
         if (loc == null || l == null) {
-            return;
+            return true;
         }
         double x = ((float) (((float) (loc.getX() - l.getX())) / (20 * speed)));
         double y = ((float) (((float) (loc.getY() - l.getY())) / (20 * speed)));
@@ -44,6 +43,7 @@ public class ArmorStandMove extends ShowAction {
         Vector motion = new Vector(x, y, z);
         stand.setMovement(new Movement(motion, speed * 20));
         ShowPlugin.getInstance().getArmorStandManager().addStand(stand, StandAction.MOVE);
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/armor/ArmorStandPosition.java
+++ b/src/main/java/network/palace/show/actions/armor/ArmorStandPosition.java
@@ -10,7 +10,6 @@ import network.palace.show.handlers.armorstand.PositionType;
 import network.palace.show.handlers.armorstand.ShowStand;
 import network.palace.show.handlers.armorstand.StandAction;
 import network.palace.show.utils.ShowUtil;
-import org.bukkit.Bukkit;
 import org.bukkit.util.EulerAngle;
 import org.bukkit.util.Vector;
 
@@ -18,10 +17,10 @@ import org.bukkit.util.Vector;
  * Created by Marc on 10/24/15
  */
 public class ArmorStandPosition extends ShowAction {
-    private ShowStand stand;
-    private PositionType positionType;
-    private EulerAngle angle;
-    private double speed;
+    private final ShowStand stand;
+    private final PositionType positionType;
+    private final EulerAngle angle;
+    private final double speed;
 
     public ArmorStandPosition(Show show, long time, ShowStand stand, PositionType positionType, EulerAngle angle, double speed) {
         super(show, time);
@@ -32,10 +31,10 @@ public class ArmorStandPosition extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         if (!stand.isHasSpawned()) {
             ShowUtil.logDebug(show.getName(), "ArmorStand with ID " + stand.getId() + " has not spawned");
-            return;
+            return true;
         }
         EulerAngle a = null;
         switch (positionType) {
@@ -64,6 +63,7 @@ public class ArmorStandPosition extends ShowAction {
         Vector motion = new Vector(x, y, z);
         stand.addPosition(new Position(motion, speed * 20, positionType));
         ShowPlugin.getInstance().getArmorStandManager().addStand(stand, StandAction.POSITION);
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/armor/ArmorStandPosition.java
+++ b/src/main/java/network/palace/show/actions/armor/ArmorStandPosition.java
@@ -31,10 +31,10 @@ public class ArmorStandPosition extends ShowAction {
     }
 
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         if (!stand.isHasSpawned()) {
             ShowUtil.logDebug(show.getName(), "ArmorStand with ID " + stand.getId() + " has not spawned");
-            return true;
+            return;
         }
         EulerAngle a = null;
         switch (positionType) {
@@ -63,11 +63,15 @@ public class ArmorStandPosition extends ShowAction {
         Vector motion = new Vector(x, y, z);
         stand.addPosition(new Position(motion, speed * 20, positionType));
         ShowPlugin.getInstance().getArmorStandManager().addStand(stand, StandAction.POSITION);
-        return true;
     }
 
     @Override
     public ShowAction load(String line, String... args) throws ShowParseException {
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new ArmorStandPosition(show, time, stand, positionType, angle, speed);
     }
 }

--- a/src/main/java/network/palace/show/actions/armor/ArmorStandRotate.java
+++ b/src/main/java/network/palace/show/actions/armor/ArmorStandRotate.java
@@ -26,21 +26,25 @@ public class ArmorStandRotate extends ShowAction {
     }
 
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         if (!stand.isHasSpawned()) {
             ShowUtil.logDebug(show.getName(), "ArmorStand with ID " + stand.getId() + " has not spawned");
-            return true;
+            return;
         }
 
         double ticks = speed * 20;
         float interval = (float) (this.yaw / ticks);
         stand.setRotation(new Rotation(interval, speed * 20));
         ShowPlugin.getInstance().getArmorStandManager().addStand(stand, StandAction.ROTATION);
-        return true;
     }
 
     @Override
     public ShowAction load(String line, String... args) throws ShowParseException {
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new ArmorStandRotate(show, time, stand, yaw, speed);
     }
 }

--- a/src/main/java/network/palace/show/actions/armor/ArmorStandRotate.java
+++ b/src/main/java/network/palace/show/actions/armor/ArmorStandRotate.java
@@ -9,15 +9,14 @@ import network.palace.show.handlers.armorstand.Rotation;
 import network.palace.show.handlers.armorstand.ShowStand;
 import network.palace.show.handlers.armorstand.StandAction;
 import network.palace.show.utils.ShowUtil;
-import org.bukkit.Bukkit;
 
 /**
  * Created by Marc on 3/26/16
  */
 public class ArmorStandRotate extends ShowAction {
-    private ShowStand stand;
-    private float yaw;
-    private double speed;
+    private final ShowStand stand;
+    private final float yaw;
+    private final double speed;
 
     public ArmorStandRotate(Show show, long time, ShowStand stand, float yaw, double speed) {
         super(show, time);
@@ -27,16 +26,17 @@ public class ArmorStandRotate extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         if (!stand.isHasSpawned()) {
             ShowUtil.logDebug(show.getName(), "ArmorStand with ID " + stand.getId() + " has not spawned");
-            return;
+            return true;
         }
 
         double ticks = speed * 20;
         float interval = (float) (this.yaw / ticks);
         stand.setRotation(new Rotation(interval, speed * 20));
         ShowPlugin.getInstance().getArmorStandManager().addStand(stand, StandAction.ROTATION);
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/armor/ArmorStandSpawn.java
+++ b/src/main/java/network/palace/show/actions/armor/ArmorStandSpawn.java
@@ -26,10 +26,10 @@ public class ArmorStandSpawn extends ShowAction {
     }
 
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         if (stand.isHasSpawned()) {
             ShowUtil.logDebug(show.getName(), "ArmorStand with ID " + stand.getId() + " has spawned already");
-            return true;
+            return;
         }
         ArmorStand armor = loc.getWorld().spawn(loc, ArmorStand.class);
         stand.spawn();
@@ -60,11 +60,15 @@ public class ArmorStandSpawn extends ShowAction {
             }
         }
         stand.setStand(armor);
-        return true;
     }
 
     @Override
     public ShowAction load(String line, String... args) throws ShowParseException {
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new ArmorStandSpawn(show, time, stand, loc);
     }
 }

--- a/src/main/java/network/palace/show/actions/armor/ArmorStandSpawn.java
+++ b/src/main/java/network/palace/show/actions/armor/ArmorStandSpawn.java
@@ -16,8 +16,8 @@ import org.bukkit.metadata.FixedMetadataValue;
  * Created by Marc on 10/11/15
  */
 public class ArmorStandSpawn extends ShowAction {
-    private ShowStand stand;
-    private Location loc;
+    private final ShowStand stand;
+    private final Location loc;
 
     public ArmorStandSpawn(Show show, long time, ShowStand stand, Location loc) {
         super(show, time);
@@ -26,10 +26,10 @@ public class ArmorStandSpawn extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         if (stand.isHasSpawned()) {
             ShowUtil.logDebug(show.getName(), "ArmorStand with ID " + stand.getId() + " has spawned already");
-            return;
+            return true;
         }
         ArmorStand armor = loc.getWorld().spawn(loc, ArmorStand.class);
         stand.spawn();
@@ -60,6 +60,7 @@ public class ArmorStandSpawn extends ShowAction {
             }
         }
         stand.setStand(armor);
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/audio/AudioStart.java
+++ b/src/main/java/network/palace/show/actions/audio/AudioStart.java
@@ -19,15 +19,19 @@ public class AudioStart extends ShowAction {
         super(show, time);
     }
 
+    public AudioStart(Show show, long time, AudioArea area) {
+        super(show, time);
+        this.area = area;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
-        if (area == null) return true;
+    public void play(CPlayer[] nearPlayers) {
+        if (area == null) return;
         show.setMusicTime(System.currentTimeMillis());
         show.setAreaName(area.getAreaName());
         for (CPlayer tp : nearPlayers) {
             if (tp != null) area.triggerPlayer(tp);
         }
-        return true;
     }
 
     @Override
@@ -35,5 +39,10 @@ public class AudioStart extends ShowAction {
         area = Audio.getInstance().getByName(args[2]);
         if (area == null) Core.logMessage(ChatColor.RED + "Show Error", "Error finding Audio Area " + args[2] + "!");
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new AudioStart(show, time, area);
     }
 }

--- a/src/main/java/network/palace/show/actions/audio/AudioStart.java
+++ b/src/main/java/network/palace/show/actions/audio/AudioStart.java
@@ -7,7 +7,6 @@ import network.palace.core.player.CPlayer;
 import network.palace.show.Show;
 import network.palace.show.actions.ShowAction;
 import network.palace.show.exceptions.ShowParseException;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 
 /**
@@ -21,15 +20,14 @@ public class AudioStart extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
-        if (area == null) return;
+    public boolean play(CPlayer[] nearPlayers) {
+        if (area == null) return true;
         show.setMusicTime(System.currentTimeMillis());
         show.setAreaName(area.getAreaName());
-        if (area != null) {
-            for (CPlayer tp : nearPlayers) {
-                if (tp != null) area.triggerPlayer(tp);
-            }
+        for (CPlayer tp : nearPlayers) {
+            if (tp != null) area.triggerPlayer(tp);
         }
+        return true;
     }
 
     @Override

--- a/src/main/java/network/palace/show/actions/audio/AudioSync.java
+++ b/src/main/java/network/palace/show/actions/audio/AudioSync.java
@@ -20,14 +20,19 @@ public class AudioSync extends ShowAction {
         super(show, time);
     }
 
+    public AudioSync(Show show, long time, float seconds, AudioArea area) {
+        super(show, time);
+        this.seconds = seconds;
+        this.area = area;
+    }
+
     @Override
-    public boolean play(CPlayer[] nearPlayers) {
+    public void play(CPlayer[] nearPlayers) {
         if (area != null) {
             for (CPlayer tp : nearPlayers) {
                 if (tp != null) area.sync(seconds, tp, 0.25);
             }
         }
-        return true;
     }
 
     @Override
@@ -38,5 +43,10 @@ public class AudioSync extends ShowAction {
             Core.logMessage(ChatColor.RED + "Show Error", "Error finding Audio Area " + args[2] + "!");
         }
         return this;
+    }
+
+    @Override
+    protected ShowAction copy(Show show, long time) throws ShowParseException {
+        return new AudioSync(show, time, seconds, area);
     }
 }

--- a/src/main/java/network/palace/show/actions/audio/AudioSync.java
+++ b/src/main/java/network/palace/show/actions/audio/AudioSync.java
@@ -7,7 +7,6 @@ import network.palace.core.player.CPlayer;
 import network.palace.show.Show;
 import network.palace.show.actions.ShowAction;
 import network.palace.show.exceptions.ShowParseException;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 
 /**
@@ -22,12 +21,13 @@ public class AudioSync extends ShowAction {
     }
 
     @Override
-    public void play(CPlayer[] nearPlayers) {
+    public boolean play(CPlayer[] nearPlayers) {
         if (area != null) {
             for (CPlayer tp : nearPlayers) {
                 if (tp != null) area.sync(seconds, tp, 0.25);
             }
         }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
This update adds the "Repeat" action, which allows a certain show action to be repeated a number of times at a defined interval.

Format: `[time] Repeat [occurrences] [interval in ticks] [action text]`

Example: `5 Repeat 7 10 Text &bHello there!`

That Text action will be executed 7 times, once every 10 ticks (0.5 seconds). The first occurrence happens immediately, with the rest delayed from there. The occurrences and interval values must be at least 1.